### PR TITLE
Add phase-based comment tags

### DIFF
--- a/components/MP3MetadataViewer.tsx
+++ b/components/MP3MetadataViewer.tsx
@@ -4,11 +4,11 @@ import type { MP3Metadata } from '../lib/mp3-metadata';
 
 interface MP3MetadataViewerProps {
   filePath: string;
-  availableTags?: string[];
+  phases?: string[];
   onPendingEditAdded?: () => void;
 }
 
-export function MP3MetadataViewer({ filePath, availableTags = [], onPendingEditAdded }: MP3MetadataViewerProps) {
+export function MP3MetadataViewer({ filePath, phases = [], onPendingEditAdded }: MP3MetadataViewerProps) {
   const [metadata, setMetadata] = useState<MP3Metadata | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -26,7 +26,7 @@ export function MP3MetadataViewer({ filePath, availableTags = [], onPendingEditA
     return tags;
   };
 
-  const updateTag = (tag: string) => {
+  const togglePhase = (tag: string) => {
     const tags = new Set(extractTags(newComment));
     if (tags.has(tag)) {
       tags.delete(tag);
@@ -120,27 +120,29 @@ export function MP3MetadataViewer({ filePath, availableTags = [], onPendingEditA
           
           {editingComment ? (
             <div className="space-y-2">
-              <textarea
-                value={newComment}
-                onChange={(e) => setNewComment(e.target.value)}
-                className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                rows={3}
-                placeholder="Enter comment..."
-              />
-              {availableTags.length > 0 && (
-                <div className="flex flex-wrap gap-2">
-                  {availableTags.map(tag => (
-                    <label key={tag} className="flex items-center space-x-1 text-xs">
-                      <input
-                        type="checkbox"
-                        checked={extractTags(newComment).includes(tag)}
-                        onChange={() => updateTag(tag)}
-                      />
-                      <span>#{tag}</span>
-                    </label>
-                  ))}
-                </div>
-              )}
+              <div className="flex items-start gap-2">
+                <input
+                  type="text"
+                  value={newComment}
+                  onChange={(e) => setNewComment(e.target.value)}
+                  className="flex-1 p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder="Enter comment..."
+                />
+                {phases.length > 0 && (
+                  <div className="flex flex-col gap-1">
+                    {phases.map(tag => (
+                      <label key={tag} className="flex items-center space-x-1 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={extractTags(newComment).includes(tag)}
+                        onChange={() => togglePhase(tag)}
+                        />
+                        <span>#{tag}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
               <div className="flex space-x-2">
                 <button
                   onClick={handleSaveComment}

--- a/components/Settings.telefunc.ts
+++ b/components/Settings.telefunc.ts
@@ -1,0 +1,9 @@
+import { savePhases, readPhases } from '../database/sqlite/queries/library-settings';
+
+export async function onGetPhases(): Promise<string[]> {
+  return readPhases();
+}
+
+export async function onSetPhases(phases: string[]): Promise<void> {
+  savePhases(phases);
+}

--- a/database/sqlite/queries/library-settings.ts
+++ b/database/sqlite/queries/library-settings.ts
@@ -1,5 +1,10 @@
 import { db } from '../db.js';
-import { setBaseFolder, getBaseFolder } from '../schema/library-settings.js';
+import {
+  setBaseFolder,
+  getBaseFolder,
+  setPhases,
+  getPhases
+} from '../schema/library-settings.js';
 
 export function saveBaseFolder(folder: string): void {
   const stmt = db().prepare(setBaseFolder);
@@ -10,4 +15,22 @@ export function readBaseFolder(): string | null {
   const stmt = db().prepare(getBaseFolder);
   const row = stmt.get() as any;
   return row ? (row.base_folder as string | null) : null;
+}
+
+export function savePhases(phases: string[]): void {
+  const stmt = db().prepare(setPhases);
+  stmt.run(JSON.stringify(phases));
+}
+
+export function readPhases(): string[] {
+  const stmt = db().prepare(getPhases);
+  const row = stmt.get() as any;
+  if (!row || row.phases == null) {
+    return ['starter', 'buildup', 'peak', 'release', 'feature'];
+  }
+  try {
+    return JSON.parse(row.phases) as string[];
+  } catch {
+    return ['starter', 'buildup', 'peak', 'release', 'feature'];
+  }
 }

--- a/database/sqlite/schema/library-settings.ts
+++ b/database/sqlite/schema/library-settings.ts
@@ -9,7 +9,8 @@ const client = db();
 client.exec(`
   CREATE TABLE IF NOT EXISTS library_settings (
     id INTEGER PRIMARY KEY CHECK (id = 1),
-    base_folder TEXT
+    base_folder TEXT,
+    phases TEXT
   );
 `);
 
@@ -21,4 +22,14 @@ export const setBaseFolder = `
 
 export const getBaseFolder = `
   SELECT base_folder FROM library_settings WHERE id = 1;
+`;
+
+export const setPhases = `
+  INSERT INTO library_settings (id, phases)
+  VALUES (1, ?)
+  ON CONFLICT(id) DO UPDATE SET phases = excluded.phases;
+`;
+
+export const getPhases = `
+  SELECT phases FROM library_settings WHERE id = 1;
 `;

--- a/layouts/LayoutDefault.tsx
+++ b/layouts/LayoutDefault.tsx
@@ -107,6 +107,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
           <Link href="/mp3-demo" label="MP3 Tags Demo" onClick={handleNavLinkClick} />
           <Link href="/mp3-library" label="MP3 Library" onClick={handleNavLinkClick} />
           <Link href="/review-changes" label="Review changes" onClick={handleNavLinkClick} />
+          <Link href="/settings" label="Settings" onClick={handleNavLinkClick} />
         </Stack>
       </AppShell.Navbar>
 

--- a/pages/mp3-demo/+Page.tsx
+++ b/pages/mp3-demo/+Page.tsx
@@ -1,12 +1,21 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { MP3MetadataViewer } from '../../components/MP3MetadataViewer';
 import { PendingEditsManager } from '../../components/PendingEditsManager';
+import { onGetPhases } from '../../components/Settings.telefunc';
 
 export function Page() {
   const [refreshKey, setRefreshKey] = useState(0);
+  const [phases, setPhases] = useState<string[]>([]);
   
   // Path to the demo MP3 file (relative to project root)
   const demoFilePath = './lifekiller.mp3';
+
+  useEffect(() => {
+    (async () => {
+      const p = await onGetPhases();
+      setPhases(p);
+    })();
+  }, []);
 
   const handleRefresh = () => {
     setRefreshKey(prev => prev + 1);
@@ -30,9 +39,10 @@ export function Page() {
             <h2 className="text-xl font-semibold text-gray-900 mb-4">
               MP3 Metadata
             </h2>
-            <MP3MetadataViewer 
+            <MP3MetadataViewer
               key={`metadata-${refreshKey}`}
               filePath={demoFilePath}
+              phases={phases}
               onPendingEditAdded={handleRefresh}
             />
           </div>

--- a/pages/mp3-library/+Page.tsx
+++ b/pages/mp3-library/+Page.tsx
@@ -11,6 +11,7 @@ import {
   onApplyPendingEdit,
   onRejectPendingEdit
 } from '../../components/MP3Library.telefunc';
+import { onGetPhases } from '../../components/Settings.telefunc';
 import type { MP3LibraryScan, MP3EditHistory } from '../../lib/mp3-library';
 import type { PendingEdit } from '../../lib/mp3-metadata';
 import { Modal, Button, Group, Stack, MultiSelect, Text, Table, Paper, Tabs, Badge } from '@mantine/core';
@@ -27,6 +28,7 @@ export default function MP3LibraryPage() {
   const [history, setHistory] = useState<MP3EditHistory[]>([]);
   const [pendingEdits, setPendingEdits] = useState<PendingEdit[]>([]);
   const [processingEdits, setProcessingEdits] = useState<Set<number>>(new Set());
+  const [phases, setPhases] = useState<string[]>([]);
 
   useEffect(() => {
     (async () => {
@@ -34,6 +36,8 @@ export default function MP3LibraryPage() {
       if (folder) {
         setBaseFolder(folder);
       }
+      const p = await onGetPhases();
+      setPhases(p);
     })();
   }, []);
 
@@ -299,7 +303,7 @@ export default function MP3LibraryPage() {
         {selectedFile && (
           <MP3MetadataViewer
             filePath={selectedFile}
-            availableTags={tags}
+            phases={phases}
             onPendingEditAdded={performScan}
           />
         )}

--- a/pages/settings/+Page.tsx
+++ b/pages/settings/+Page.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { TextInput, Button, Stack, Group, Text } from '@mantine/core';
+import { onGetPhases, onSetPhases } from '../../components/Settings.telefunc';
+
+export default function SettingsPage() {
+  const [phasesStr, setPhasesStr] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const phases = await onGetPhases();
+      setPhasesStr(phases.join(', '));
+    })();
+  }, []);
+
+  const handleSave = async () => {
+    const phases = phasesStr
+      .split(',')
+      .map(p => p.trim())
+      .filter(p => p.length > 0);
+    await onSetPhases(phases);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <Stack gap="md">
+      <Text fw={600} size="lg">Settings</Text>
+      <TextInput
+        label="Phases (comma separated)"
+        value={phasesStr}
+        onChange={e => setPhasesStr(e.currentTarget.value)}
+      />
+      <Group>
+        <Button size="xs" onClick={handleSave}>Save</Button>
+        {saved && <Text c="green">Saved!</Text>}
+      </Group>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- store phase names in SQLite settings
- expose phase settings via new telefunc and settings page
- adjust MP3 metadata viewer to use phases and checkboxes
- fetch phases in MP3 pages and wire up navigation

## Testing
- `npm run lint` *(fails: jiti missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a9d510dfc8323a91b1ca91cfb7f48